### PR TITLE
Feature/issue 28/delivery policy

### DIFF
--- a/src/main/java/shop/wannab/order_payment_service/controller/DeliveryPolicyController.java
+++ b/src/main/java/shop/wannab/order_payment_service/controller/DeliveryPolicyController.java
@@ -1,0 +1,65 @@
+package shop.wannab.order_payment_service.controller;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.wannab.order_payment_service.entity.DeliveryPolicy;
+import shop.wannab.order_payment_service.entity.dto.DeliveryPolicyRequest;
+import shop.wannab.order_payment_service.entity.dto.DeliveryPolicyResponse;
+import shop.wannab.order_payment_service.service.DeliveryPolicyService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/delivery-policy")
+public class DeliveryPolicyController {
+
+    private final DeliveryPolicyService deliveryPolicyService;
+
+
+    //생성
+    @PostMapping
+    public ResponseEntity<DeliveryPolicyResponse> createDeliveryPolicy(@RequestBody @Valid DeliveryPolicyRequest request){
+
+        DeliveryPolicy dp = deliveryPolicyService.createDeliveryPolicy(request);
+
+        //반환하기위해 response에 담음
+        DeliveryPolicyResponse response = new DeliveryPolicyResponse(dp.getId(), dp.getName(), dp.getMinPrice(), dp.getFee());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    //수정
+    @PutMapping("{dp-id}")
+    public ResponseEntity<DeliveryPolicyResponse> updateDeliveryPolicy(@RequestBody @Valid DeliveryPolicyRequest request,
+                                                                       @PathVariable("dp-id") Long id){
+        DeliveryPolicy dp = deliveryPolicyService.updateDeliveryPolicy(id, request);
+
+        //반환하기위해 response에 담음
+        DeliveryPolicyResponse response = new DeliveryPolicyResponse(dp.getId(), dp.getName(), dp.getMinPrice(), dp.getFee());
+        return ResponseEntity.ok(response);
+    }
+
+    //삭제
+    @DeleteMapping("{dp-id}")
+    public ResponseEntity<Void> deleteDeliverPolicy(@PathVariable("dp-id") Long id){
+
+        deliveryPolicyService.deleteDeliveryPolicy(id);
+        return ResponseEntity.ok().build();
+    }
+
+    //전체목록조회
+    @GetMapping
+    public ResponseEntity<List<DeliveryPolicyResponse>> getDeliveryPolicyList(){
+        List<DeliveryPolicyResponse> list = deliveryPolicyService.getDeliveryPolicyList();
+        return ResponseEntity.ok(list);
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/DeliveryPolicy.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/DeliveryPolicy.java
@@ -39,7 +39,7 @@ public class DeliveryPolicy {
 
 
     //배송정책 계산로직 (우선 배송정책쪽에 넣었는데 나중에 바꿀필요가 있으면 수정필요)
-    public boolean isApplicable(int orderPrice) {
-        return orderPrice >= this.minPrice;
+    public boolean isApplicable(int totalBookPrice) {
+        return totalBookPrice >= this.minPrice;
     }
 }

--- a/src/main/java/shop/wannab/order_payment_service/entity/DeliveryPolicy.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/DeliveryPolicy.java
@@ -1,0 +1,45 @@
+package shop.wannab.order_payment_service.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "delivery_policy")
+public class DeliveryPolicy {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "dp_id")
+    private Long id;
+
+    @Setter
+    @Column(name = "dp_name", unique = true)
+    @NotNull
+    private String name;
+
+    @Setter
+    @Column(name = "dp_fee")
+    @NotNull
+    private int fee;
+
+    @Setter
+    @Column(name = "dp_min")
+    @NotNull
+    private int minPrice;
+
+
+    //배송정책 계산로직 (우선 배송정책쪽에 넣었는데 나중에 바꿀필요가 있으면 수정필요)
+    public boolean isApplicable(int orderPrice) {
+        return orderPrice >= this.minPrice;
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/DeliveryPolicyRequest.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/DeliveryPolicyRequest.java
@@ -1,0 +1,19 @@
+package shop.wannab.order_payment_service.entity.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Data;
+
+@Data
+public class DeliveryPolicyRequest {
+    @NotBlank(message = "정책명은 필수로 입력해야 합니다")
+    private String name;    // 정책명
+
+    @PositiveOrZero(message = "최소주문금액은 0보다 작을 수 없습니다.")
+    private int minPrice;   // 최소주문금액 (이 금액을 넘어야 정책이 적용)
+
+    @PositiveOrZero(message = "배송비는 0보다 작을 수 없습니다.")
+    private int fee;    // 배송비
+
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/DeliveryPolicyResponse.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/DeliveryPolicyResponse.java
@@ -1,0 +1,13 @@
+package shop.wannab.order_payment_service.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DeliveryPolicyResponse {
+    private final Long id;    // 정책id
+    private final String name;    // 정책명
+    private final int minPrice;   // 최소주문금액 (이 금액을 넘어야 정책이 적용)
+    private final int fee;    // 배송비
+}

--- a/src/main/java/shop/wannab/order_payment_service/exception/DeliveryPolicyAlreadyExistsException.java
+++ b/src/main/java/shop/wannab/order_payment_service/exception/DeliveryPolicyAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package shop.wannab.order_payment_service.exception;
+
+public class DeliveryPolicyAlreadyExistsException extends RuntimeException {
+    public DeliveryPolicyAlreadyExistsException(String name) {
+        super("이미 존재하는 정책입니다 : " + name);
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/exception/DeliveryPolicyNotFoundException.java
+++ b/src/main/java/shop/wannab/order_payment_service/exception/DeliveryPolicyNotFoundException.java
@@ -1,0 +1,7 @@
+package shop.wannab.order_payment_service.exception;
+
+public class DeliveryPolicyNotFoundException extends RuntimeException {
+    public DeliveryPolicyNotFoundException(Long id) {
+        super("배송비 정책을 찾을 수 없습니다 : " + id);
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/repository/DeliveryPolicyRepository.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/DeliveryPolicyRepository.java
@@ -1,0 +1,12 @@
+package shop.wannab.order_payment_service.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import shop.wannab.order_payment_service.entity.DeliveryPolicy;
+
+
+public interface DeliveryPolicyRepository extends JpaRepository<DeliveryPolicy, Long> {
+    boolean existsByName(String name);
+    Optional<DeliveryPolicy> findByName(String name);
+}

--- a/src/main/java/shop/wannab/order_payment_service/service/DeliveryPolicyService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/DeliveryPolicyService.java
@@ -1,0 +1,30 @@
+package shop.wannab.order_payment_service.service;
+
+
+import java.util.List;
+import shop.wannab.order_payment_service.entity.DeliveryPolicy;
+import shop.wannab.order_payment_service.entity.dto.DeliveryPolicyRequest;
+import shop.wannab.order_payment_service.entity.dto.DeliveryPolicyResponse;
+
+public interface DeliveryPolicyService {
+
+    // 정책 생성
+    DeliveryPolicy createDeliveryPolicy(DeliveryPolicyRequest request);
+
+    // 정책 수정
+    DeliveryPolicy updateDeliveryPolicy(Long id, DeliveryPolicyRequest request);
+
+    // 정책 삭제
+    void deleteDeliveryPolicy(Long id);
+
+    // 정책 전체 목록 조회
+    List<DeliveryPolicyResponse> getDeliveryPolicyList();
+
+
+
+    //계산로직
+    DeliveryPolicy findApplicablePolicy(int orderPrice);
+
+    //기본배송비정책반환 -> 계산로직에서 필요
+    DeliveryPolicy getDefaultPolicy();
+}

--- a/src/main/java/shop/wannab/order_payment_service/service/Impl/DeliveryPolicyServiceImpl.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/Impl/DeliveryPolicyServiceImpl.java
@@ -1,0 +1,101 @@
+package shop.wannab.order_payment_service.service.Impl;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.wannab.order_payment_service.entity.DeliveryPolicy;
+import shop.wannab.order_payment_service.entity.dto.DeliveryPolicyRequest;
+import shop.wannab.order_payment_service.entity.dto.DeliveryPolicyResponse;
+import shop.wannab.order_payment_service.exception.DeliveryPolicyAlreadyExistsException;
+import shop.wannab.order_payment_service.exception.DeliveryPolicyNotFoundException;
+import shop.wannab.order_payment_service.repository.DeliveryPolicyRepository;
+import shop.wannab.order_payment_service.service.DeliveryPolicyService;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryPolicyServiceImpl implements DeliveryPolicyService {
+
+    private final DeliveryPolicyRepository deliveryPolicyRepository;
+
+    //생성
+    @Transactional
+    @Override
+    public DeliveryPolicy createDeliveryPolicy(DeliveryPolicyRequest request) {
+
+        // 이름 중복검사
+        if(deliveryPolicyRepository.existsByName(request.getName())){
+            throw new DeliveryPolicyAlreadyExistsException(request.getName());
+        }
+
+        DeliveryPolicy deliveryPolicy = new DeliveryPolicy();
+        deliveryPolicy.setName(request.getName());
+        deliveryPolicy.setFee(request.getFee());
+        deliveryPolicy.setMinPrice(request.getMinPrice());
+
+        return deliveryPolicyRepository.save(deliveryPolicy);
+    }
+
+    //수정
+    @Transactional
+    @Override
+    public DeliveryPolicy updateDeliveryPolicy(Long id, DeliveryPolicyRequest request) {
+
+        //정책 유무 검사
+        DeliveryPolicy deliveryPolicy = deliveryPolicyRepository.findById(id).orElseThrow(()-> new DeliveryPolicyNotFoundException(id));
+
+        // 이름 중복검사 -> 같은 정책수정에 대해서는 이름중복예외처리 x
+        deliveryPolicyRepository.findByName(request.getName()).ifPresent(dp -> {
+            if (!dp.getId().equals(id)) {
+                throw new DeliveryPolicyAlreadyExistsException(request.getName());
+            }
+        });
+
+        deliveryPolicy.setName(request.getName());
+        deliveryPolicy.setFee(request.getFee());
+        deliveryPolicy.setMinPrice(request.getMinPrice());
+
+        return deliveryPolicy;
+    }
+
+    //삭제
+    @Transactional
+    @Override
+    public void deleteDeliveryPolicy(Long id) {
+        //정책 유무 검사
+        DeliveryPolicy deliveryPolicy = deliveryPolicyRepository.findById(id).orElseThrow(()-> new DeliveryPolicyNotFoundException(id));
+
+        deliveryPolicyRepository.deleteById(id);
+    }
+
+    //전체목록조회
+    @Transactional(readOnly = true)
+    @Override
+    public List<DeliveryPolicyResponse> getDeliveryPolicyList() {
+
+        //DTO로 변환하기위해 매핑처리
+        return deliveryPolicyRepository.findAll().stream()
+                .map(dp -> new DeliveryPolicyResponse(dp.getId(), dp.getName(), dp.getMinPrice(), dp.getFee()))
+                .collect(Collectors.toList());
+    }
+
+
+    //정책 계산 로직 -> 주문한 금액을 받고 그 금액에 알맞는 배송 정책을 반환
+    @Override
+    public DeliveryPolicy findApplicablePolicy(int orderPrice) {
+        List<DeliveryPolicy> list = deliveryPolicyRepository.findAll();
+
+        return list.stream().filter(dp -> dp.isApplicable(orderPrice))
+                .max(Comparator.comparingInt(DeliveryPolicy::getMinPrice))
+                .orElseGet(this::getDefaultPolicy);
+    }
+
+    //기본 배송비정책 로직
+    @Override
+    public DeliveryPolicy getDefaultPolicy() {
+        return deliveryPolicyRepository.findByName("기본배송비").orElseThrow(()-> new IllegalArgumentException("배송비 기본정책이 설정되어있지 않습니다."));
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/service/Impl/DeliveryPolicyServiceImpl.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/Impl/DeliveryPolicyServiceImpl.java
@@ -85,10 +85,10 @@ public class DeliveryPolicyServiceImpl implements DeliveryPolicyService {
 
     //정책 계산 로직 -> 주문한 금액을 받고 그 금액에 알맞는 배송 정책을 반환
     @Override
-    public DeliveryPolicy findApplicablePolicy(int orderPrice) {
+    public DeliveryPolicy findApplicablePolicy(int totalBookPrice) {
         List<DeliveryPolicy> list = deliveryPolicyRepository.findAll();
 
-        return list.stream().filter(dp -> dp.isApplicable(orderPrice))
+        return list.stream().filter(dp -> dp.isApplicable(totalBookPrice))
                 .max(Comparator.comparingInt(DeliveryPolicy::getMinPrice))
                 .orElseGet(this::getDefaultPolicy);
     }


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

> 배송정책 추가, 수정, 삭제, 전체조회(CRUD)를 구현하고 주문금액에 따른 정책선택로직을 구현

## 🔎 작업 상세 내용

- [x] Entity, Repository, Sevice, Controller 구현완료
- [x] 배송비 정책명 중복에 대한 예외처리 구현 ( 같은id에 대한 정책 수정시, 이름중복 예외처리넘김 )
- [x] 주문금액보다 정책에대한 최소금액을 만족하는지에 대한 메소드 구현 및 정책계산, 기본배송비정책에 대한 설정 로직추가(_isApplicable(int totalBookPrice), findApplicablePlicy(int totalBookPrice), getDefaultPolicy()_  )
      
## ⏰ Pull Request 마감시간
> 17일 14:30

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
