### PR TITLE
issue-30/order: 주문페이지 생성시 필요한 정보 취합 기능(쿠폰 차후 적용 예정)

### DIFF
--- a/http/test.http
+++ b/http/test.http
@@ -1,0 +1,20 @@
+### 도서 주문 유효성 검증 요청
+POST http://localhost:8081/api/books/validate-order-items
+Content-Type: application/json
+
+{
+  "orderItems": [
+    {
+      "bookId": 1,
+      "quantity": 5
+    },
+    {
+      "bookId": 2,
+      "quantity": 10
+    },
+    {
+      "bookId": 3,
+      "quantity": 1
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,21 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
 		</dependency>
 
 		<dependency>
+        	<groupId>org.springframework.cloud</groupId>
+        	<artifactId>spring-cloud-starter-loadbalancer</artifactId>
+    	</dependency>
+
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/shop/wannab/order_payment_service/OrderPaymentServiceApplication.java
+++ b/src/main/java/shop/wannab/order_payment_service/OrderPaymentServiceApplication.java
@@ -2,9 +2,11 @@ package shop.wannab.order_payment_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableFeignClients
+@EnableDiscoveryClient
 @SpringBootApplication
 public class OrderPaymentServiceApplication {
 

--- a/src/main/java/shop/wannab/order_payment_service/OrderPaymentServiceApplication.java
+++ b/src/main/java/shop/wannab/order_payment_service/OrderPaymentServiceApplication.java
@@ -2,7 +2,9 @@ package shop.wannab.order_payment_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class OrderPaymentServiceApplication {
 

--- a/src/main/java/shop/wannab/order_payment_service/advice/OrderPaymentControllerAdvice.java
+++ b/src/main/java/shop/wannab/order_payment_service/advice/OrderPaymentControllerAdvice.java
@@ -1,0 +1,35 @@
+package shop.wannab.order_payment_service.advice;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import shop.wannab.order_payment_service.entity.dto.OrderBookInfo;
+import shop.wannab.order_payment_service.exception.UnavailableOrderBooksException;
+import shop.wannab.order_payment_service.service.CartService;
+
+import java.util.List;
+
+@ControllerAdvice
+@RequiredArgsConstructor
+public class OrderPaymentControllerAdvice {
+
+    private final CartService cartService;
+
+    @ExceptionHandler({UnavailableOrderBooksException.class})
+    public ResponseEntity<String> handleUnavailableOrderBooksException(UnavailableOrderBooksException exception) {
+        List<OrderBookInfo> invalidBooks = exception.getInvalidBooks();
+        StringBuilder sb = new StringBuilder();
+        for (OrderBookInfo book : invalidBooks) {
+            sb.append(book.getTitle()).append(", ");
+            //만약 책이 판매중지되면, 장바구니의 책 삭제
+            if (book.getQuantity() == -1) {
+                cartService.removeProductFromCart(exception.getUserId(), book.getId());
+            }
+        }
+        sb.setLength(sb.length() - 2);
+        sb.append("는 주문 불가합니다(판매중지 또는 재고부족)");
+        return new ResponseEntity<>(sb.toString(), HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/advice/OrderPaymentControllerAdvice.java
+++ b/src/main/java/shop/wannab/order_payment_service/advice/OrderPaymentControllerAdvice.java
@@ -1,35 +1,12 @@
 package shop.wannab.order_payment_service.advice;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import shop.wannab.order_payment_service.entity.dto.OrderBookInfo;
-import shop.wannab.order_payment_service.exception.UnavailableOrderBooksException;
-import shop.wannab.order_payment_service.service.CartService;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.List;
 
-@ControllerAdvice
+@RestControllerAdvice
 @RequiredArgsConstructor
 public class OrderPaymentControllerAdvice {
 
-    private final CartService cartService;
 
-    @ExceptionHandler({UnavailableOrderBooksException.class})
-    public ResponseEntity<String> handleUnavailableOrderBooksException(UnavailableOrderBooksException exception) {
-        List<OrderBookInfo> invalidBooks = exception.getInvalidBooks();
-        StringBuilder sb = new StringBuilder();
-        for (OrderBookInfo book : invalidBooks) {
-            sb.append(book.getTitle()).append(", ");
-            //만약 책이 판매중지되면, 장바구니의 책 삭제
-            if (book.getQuantity() == -1) {
-                cartService.removeProductFromCart(exception.getUserId(), book.getId());
-            }
-        }
-        sb.setLength(sb.length() - 2);
-        sb.append("는 주문 불가합니다(판매중지 또는 재고부족)");
-        return new ResponseEntity<>(sb.toString(), HttpStatus.CONFLICT);
-    }
 }

--- a/src/main/java/shop/wannab/order_payment_service/client/BookClient.java
+++ b/src/main/java/shop/wannab/order_payment_service/client/BookClient.java
@@ -1,0 +1,16 @@
+package shop.wannab.order_payment_service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import shop.wannab.order_payment_service.entity.dto.OrderBookInfoListDto;
+import shop.wannab.order_payment_service.entity.dto.OrderItemListDto;
+
+@FeignClient(name = "wannab-book-service", url = "${book.api.url}") //수정 필요할 수도
+public interface BookClient {
+
+    @PostMapping("/api/books/validate-order-items")
+    void validateOrderItems(@RequestBody OrderItemListDto orderItemListDto);
+    @PostMapping("/api/books/temp")
+    OrderBookInfoListDto getOrderBookInfos(OrderItemListDto orderItemListDto);
+}

--- a/src/main/java/shop/wannab/order_payment_service/client/UserClient.java
+++ b/src/main/java/shop/wannab/order_payment_service/client/UserClient.java
@@ -1,0 +1,18 @@
+package shop.wannab.order_payment_service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import shop.wannab.order_payment_service.entity.dto.UserAddressResponse;
+
+import java.util.List;
+
+@FeignClient(name = "wannab-user-service")
+public interface UserClient {
+    @GetMapping("/api/users/{user-id}/points")
+    int getUserPoints(@PathVariable("user-id") Long userId, @RequestHeader("X-USER-ID") Long headerUserId);
+
+    @GetMapping
+    List<UserAddressResponse> getAllAddresses(@RequestHeader("X-USER-ID") Long userId);
+}

--- a/src/main/java/shop/wannab/order_payment_service/controller/OrderController.java
+++ b/src/main/java/shop/wannab/order_payment_service/controller/OrderController.java
@@ -1,39 +1,27 @@
 package shop.wannab.order_payment_service.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import shop.wannab.order_payment_service.client.BookClient;
-import shop.wannab.order_payment_service.client.UserClient;
 import shop.wannab.order_payment_service.entity.dto.*;
 import shop.wannab.order_payment_service.service.OrderService;
-import shop.wannab.order_payment_service.service.WrappingPaperService;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/orders")
 @RequiredArgsConstructor
 public class OrderController {
-    private final UserClient userClient;
     private final BookClient bookClient;
     private final OrderService orderService;
-    private final WrappingPaperService wrappingPaperService;
 
 
     @PostMapping
-    public OrderPageRequestDto getNecesaryOrderInfo(@RequestHeader("X-User-Id") Long userId, @RequestBody OrderItemListDto orderItemListDto) throws JsonProcessingException {
-        bookClient.validateOrderItems(orderItemListDto); //프론트까지 에러 전달
-
-        OrderBookInfoListDto orderBookInfos = bookClient.getOrderBookInfos(orderItemListDto);
-        int totalBookPrice = orderService.getTotalBookPrice(orderBookInfos);    // 총 도서 금액
-        int shippingFee = orderService.getShippingFee(totalBookPrice);          // 배송비
-        int userPoints = userClient.getUserPoints(userId, userId);                      //가용할 수 있는 유저포인트
-        List<UserAddressResponse> userAddresses = userClient.getAllAddresses(userId);
-        List<WrappingPaperResponse> wrappingPaperList = wrappingPaperService.getWrappingPaperList(); //포장지 리스트
-        //TODO: 유저아이디, 책목록으로 쿠폰쪽에 rest request보내서, 사용할 수 있는 쿠폰리스트 받기
-
-        OrderPageRequestDto orderPageRequestDto = new OrderPageRequestDto(orderBookInfos, userAddresses, wrappingPaperList, totalBookPrice, shippingFee, userPoints);
-        return orderPageRequestDto;
+    public OrderPageRequestDto getNecesaryOrderInfo(@RequestHeader("X-User-Id") Long userId, @RequestBody OrderItemListDto orderItemListDto) {
+        try {
+            bookClient.validateOrderItems(orderItemListDto);
+        } catch (FeignException.BadRequest e) {
+            throw e;
+        }
+        return orderService.createOrderPageRequestDto(userId, orderItemListDto);
     }
 }

--- a/src/main/java/shop/wannab/order_payment_service/controller/OrderController.java
+++ b/src/main/java/shop/wannab/order_payment_service/controller/OrderController.java
@@ -1,0 +1,39 @@
+package shop.wannab.order_payment_service.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import shop.wannab.order_payment_service.client.BookClient;
+import shop.wannab.order_payment_service.client.UserClient;
+import shop.wannab.order_payment_service.entity.dto.*;
+import shop.wannab.order_payment_service.service.OrderService;
+import shop.wannab.order_payment_service.service.WrappingPaperService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+    private final UserClient userClient;
+    private final BookClient bookClient;
+    private final OrderService orderService;
+    private final WrappingPaperService wrappingPaperService;
+
+
+    @PostMapping
+    public OrderPageRequestDto getNecesaryOrderInfo(@RequestHeader("X-User-Id") Long userId, @RequestBody OrderItemListDto orderItemListDto) throws JsonProcessingException {
+        bookClient.validateOrderItems(orderItemListDto); //프론트까지 에러 전달
+
+        OrderBookInfoListDto orderBookInfos = bookClient.getOrderBookInfos(orderItemListDto);
+        int totalBookPrice = orderService.getTotalBookPrice(orderBookInfos);    // 총 도서 금액
+        int shippingFee = orderService.getShippingFee(totalBookPrice);          // 배송비
+        int userPoints = userClient.getUserPoints(userId, userId);                      //가용할 수 있는 유저포인트
+        List<UserAddressResponse> userAddresses = userClient.getAllAddresses(userId);
+        List<WrappingPaperResponse> wrappingPaperList = wrappingPaperService.getWrappingPaperList(); //포장지 리스트
+        //TODO: 유저아이디, 책목록으로 쿠폰쪽에 rest request보내서, 사용할 수 있는 쿠폰리스트 받기
+
+        OrderPageRequestDto orderPageRequestDto = new OrderPageRequestDto(orderBookInfos, userAddresses, wrappingPaperList, totalBookPrice, shippingFee, userPoints);
+        return orderPageRequestDto;
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderBookInfo.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderBookInfo.java
@@ -1,0 +1,16 @@
+package shop.wannab.order_payment_service.entity.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrderBookInfo {
+    private long id;
+    private String title;
+    private int originPrice;
+    private int salesPrice;
+    private int quantity;
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderBookInfoListDto.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderBookInfoListDto.java
@@ -1,0 +1,14 @@
+package shop.wannab.order_payment_service.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderBookInfoListDto {
+    private List<OrderBookInfo> orderBookInfos;
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderItemListDto.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderItemListDto.java
@@ -1,0 +1,15 @@
+package shop.wannab.order_payment_service.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.wannab.order_payment_service.entity.CartItem;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class OrderItemListDto {
+    private List<CartItem> orderItems;
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderItemValidationError.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderItemValidationError.java
@@ -1,0 +1,11 @@
+package shop.wannab.order_payment_service.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderItemValidationError {
+    private long bookId;
+    private String message;
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderPageRequestDto.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderPageRequestDto.java
@@ -1,0 +1,16 @@
+package shop.wannab.order_payment_service.entity.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class OrderPageRequestDto {
+    private OrderBookInfoListDto orderBookInfoListDto;
+    private List<UserAddressResponse> userAddressList;
+    private List<WrappingPaperResponse> wrappingPaperList;
+    private int totalBookPrice;
+    private int shippingFee;
+    private int userPoints;
+    //TODO: coupon정보들..
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/UserAddressResponse.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/UserAddressResponse.java
@@ -1,0 +1,11 @@
+package shop.wannab.order_payment_service.entity.dto;
+
+import lombok.Data;
+
+@Data
+public class UserAddressResponse {
+    private Long addressId;
+    private String addressName;
+    private String address;
+    private String detailAddress;
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/WrappingPaperResponse.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/WrappingPaperResponse.java
@@ -2,9 +2,11 @@ package shop.wannab.order_payment_service.entity.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 
 @Data
 @AllArgsConstructor
+@Getter
 public class WrappingPaperResponse {
     private final Long wpId; // 포장지 옵션 ID
     private final String name; // 포장지 이름

--- a/src/main/java/shop/wannab/order_payment_service/exception/UnavailableOrderBooksException.java
+++ b/src/main/java/shop/wannab/order_payment_service/exception/UnavailableOrderBooksException.java
@@ -1,24 +1,15 @@
 package shop.wannab.order_payment_service.exception;
 
-import shop.wannab.order_payment_service.entity.dto.OrderBookInfo;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import shop.wannab.order_payment_service.entity.dto.OrderItemValidationError;
 
 import java.util.List;
 
+@Getter
+@RequiredArgsConstructor
 public class UnavailableOrderBooksException extends RuntimeException {
-    private final List<OrderBookInfo> invalidBooks;
-    private final Long userId;
-    public UnavailableOrderBooksException(Long userId, List<OrderBookInfo> invalidBooks) {
-        //super("One or more books have invalid quantity (<= 0)");
-        this.invalidBooks = invalidBooks;
-        this.userId = userId;
-    }
+    private final List<OrderItemValidationError> errors;
 
-    public List<OrderBookInfo> getInvalidBooks() {
-        return invalidBooks;
-    }
-
-    public Long getUserId() {
-        return userId;
-    }
 }
 

--- a/src/main/java/shop/wannab/order_payment_service/exception/UnavailableOrderBooksException.java
+++ b/src/main/java/shop/wannab/order_payment_service/exception/UnavailableOrderBooksException.java
@@ -1,0 +1,24 @@
+package shop.wannab.order_payment_service.exception;
+
+import shop.wannab.order_payment_service.entity.dto.OrderBookInfo;
+
+import java.util.List;
+
+public class UnavailableOrderBooksException extends RuntimeException {
+    private final List<OrderBookInfo> invalidBooks;
+    private final Long userId;
+    public UnavailableOrderBooksException(Long userId, List<OrderBookInfo> invalidBooks) {
+        //super("One or more books have invalid quantity (<= 0)");
+        this.invalidBooks = invalidBooks;
+        this.userId = userId;
+    }
+
+    public List<OrderBookInfo> getInvalidBooks() {
+        return invalidBooks;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}
+

--- a/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
@@ -2,9 +2,10 @@ package shop.wannab.order_payment_service.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import shop.wannab.order_payment_service.client.BookClient;
+import shop.wannab.order_payment_service.client.UserClient;
 import shop.wannab.order_payment_service.entity.DeliveryPolicy;
-import shop.wannab.order_payment_service.entity.dto.OrderBookInfo;
-import shop.wannab.order_payment_service.entity.dto.OrderBookInfoListDto;
+import shop.wannab.order_payment_service.entity.dto.*;
 
 import java.util.List;
 
@@ -12,6 +13,26 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrderService {
     private final DeliveryPolicyService deliveryPolicyService;
+    private final UserClient userClient;
+    private final BookClient bookClient;
+    private final WrappingPaperService wrappingPaperService;
+
+    public OrderPageRequestDto createOrderPageRequestDto(Long userId, OrderItemListDto orderItemListDto) {
+        OrderBookInfoListDto orderBookInfos = bookClient.getOrderBookInfos(orderItemListDto);
+        int totalBookPrice = getTotalBookPrice(orderBookInfos);
+        int shippingFee = getShippingFee(totalBookPrice);
+        int userPoints = 0;
+        List<UserAddressResponse> userAddresses = List.of();
+
+        if (userId > 0) {
+            userPoints = userClient.getUserPoints(userId, userId);
+            userAddresses = userClient.getAllAddresses(userId);
+        }
+
+        List<WrappingPaperResponse> wrappingPaperList = wrappingPaperService.getWrappingPaperList();
+        //TODO: coupon 정보 추후에 추가
+        return new OrderPageRequestDto(orderBookInfos, userAddresses, wrappingPaperList, totalBookPrice, shippingFee, userPoints);
+    }
 
     public int getTotalBookPrice(OrderBookInfoListDto orderBookInfoListDto) {
         int sum = 0;

--- a/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
@@ -1,0 +1,30 @@
+package shop.wannab.order_payment_service.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import shop.wannab.order_payment_service.entity.DeliveryPolicy;
+import shop.wannab.order_payment_service.entity.dto.OrderBookInfo;
+import shop.wannab.order_payment_service.entity.dto.OrderBookInfoListDto;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+    private final DeliveryPolicyService deliveryPolicyService;
+
+    public int getTotalBookPrice(OrderBookInfoListDto orderBookInfoListDto) {
+        int sum = 0;
+        List<OrderBookInfo> bookInfos = orderBookInfoListDto.getOrderBookInfos();
+        for (OrderBookInfo bookInfo : bookInfos) {
+            sum += bookInfo.getSalesPrice() * bookInfo.getQuantity();
+        }
+        return sum;
+    }
+
+    public int getShippingFee(int totalBookPrice) {
+        DeliveryPolicy deliveryPolicy = deliveryPolicyService.findApplicablePolicy(totalBookPrice);
+        int shippingFee = deliveryPolicy.getFee();
+        return shippingFee;
+    }
+}

--- a/src/main/resources/application-h2.yml
+++ b/src/main/resources/application-h2.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,11 @@ spring:
     config:
       enabled: false
 
+management:
+  health:
+    rabbit:
+      enabled: false #tmp(local용)
+
 eureka:
   client:
     enabled: false
@@ -26,6 +31,7 @@ eureka:
       database: ${REDIS_DATABASE}
 
   rabbitmq:
+
     host: ${RABBITMQ_HOST}
     port: ${RABBITMQ_PORT}
     username: ${RABBITMQ_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,23 @@
 server:
-  port: 8080
+  port: ${ORDER_PAYMENT_SERVICE_PORT}
+  shutdown: graceful
 
 spring:
   application:
     name: order-payment-service
   config:
     import: optional:classpath:properties/env.properties
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+  cloud:
+    discovery:
+      enabled: false
+    config:
+      enabled: false
 
-
+eureka:
+  client:
+    enabled: false
   data:
     redis:
       host: ${REDIS_HOST}
@@ -27,4 +37,6 @@ tosspayments:
 
 book:
   api:
-    url: http://localhost:8081
+    url: ${BOOK_SERVICE_URL}
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,12 @@
+server:
+  port: 8080
+
 spring:
   application:
     name: order-payment-service
   config:
     import: optional:classpath:properties/env.properties
+
 
   data:
     redis:
@@ -20,3 +24,7 @@ spring:
 tosspayments:
   client-key: ${TOSS_CLIENT_KEY}
   secret-key: ${TOSS_SECRET_KEY}
+
+book:
+  api:
+    url: http://localhost:8081


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

장바구니 -> 주문 페이지 넘어갈 때, 책을 구매가능한지 여부 검증 및 필요한 정보들(책정보,수량,보유쿠폰들,유저 주소, 유저 포인트 등..) 취합하여 front로 전달
## 🔎 작업 상세 내용

book-api의 검증메서드 호출 및  주문페이지에서 필요한 정보들 취합하여 전달 기능 구현

book-api에서 검증내역: 상품 존재여부, 상품 재고 체크, 판매여부 확인

## ⏰ Pull Request 마감시간
> 6월19일20:00

## 📚 참고할만한 자료(선택)
https://github.com/nhnacademy-be10-WannaB/wannab-book-service/pull/5
## 🔗 관련 이슈
Closes #30 
