### PR TITLE
issue-79/cart permanent save: 장바구니 영구저장 구현

### DIFF
--- a/src/main/java/shop/wannab/order_payment_service/client/UserClient.java
+++ b/src/main/java/shop/wannab/order_payment_service/client/UserClient.java
@@ -22,7 +22,7 @@ public interface UserClient {
     void cancleOrderPointProcess(@PathVariable("order-id") Long orderId);
 
     //주문 취소시 포인트 반환(반환받을 포인트값만 던져줌)
-    @PatchMapping("/api/users/points/refund")
+    @PostMapping("/api/users/points/refund")
     void refundPoint(@RequestHeader("X-USER-ID") Long headerUserId,
                      @RequestParam("amount") int refundPoint);
 

--- a/src/main/java/shop/wannab/order_payment_service/controller/CartController.java
+++ b/src/main/java/shop/wannab/order_payment_service/controller/CartController.java
@@ -25,7 +25,7 @@ public class CartController {
     }
 
     @GetMapping
-    public OrderBookInfoListDto getCartItems(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestBody Long guestId) {
+    public OrderBookInfoListDto getCartItems(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestBody(required = false) Long guestId) {
         if (Objects.nonNull(userId)) {
             return cartService.getCartItemInfos(userId);
         }
@@ -33,33 +33,34 @@ public class CartController {
     }
 
     @PostMapping("/books")
-    public OrderBookInfoListDto addProductToCart(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestBody Long guestId, @RequestParam Long bookId) {
+    public void addProductToCart(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestBody(required = false) Long guestId, @RequestParam Long bookId) {
         if (Objects.nonNull(userId)) {
             cartService.addCartItem(userId, bookId);
-            return cartService.getCartItemInfos(userId);
+        } else {
+            cartService.addCartItem(guestId, bookId);
         }
-        cartService.addCartItem(guestId, bookId);
-        return cartService.getCartItemInfos(guestId);
     }
 
     @PutMapping("/books/{book-id}")
-    public OrderBookInfoListDto updateCartItemQuantity(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestBody Long guestId, @PathVariable(name = "book-id") Long bookId, @RequestParam int quantity) {
+    public void updateCartItemQuantity(@RequestHeader(value = "X-USER-ID", required = false) Long userId,
+                                                       @RequestBody(required = false) Long guestId,
+                                                       @PathVariable(name = "book-id") Long bookId,
+                                                       @RequestParam int quantity) {
         if (Objects.nonNull(userId)) {
             cartService.updateItemQuantity(userId, bookId, quantity);
-            return cartService.getCartItemInfos(userId);
+        } else {
+            cartService.updateItemQuantity(guestId, bookId, quantity);
         }
-        cartService.updateItemQuantity(guestId, bookId, quantity);
-        return cartService.getCartItemInfos(guestId);
+
     }
 
     @DeleteMapping("/books/{book-id}")
-    public OrderBookInfoListDto removeProductFromCart(@RequestHeader("X-USER-ID") Long userId, @RequestBody Long guestId, @PathVariable(name = "book-id") Long bookId) {
+    public void removeProductFromCart(@RequestHeader("X-USER-ID") Long userId, @RequestBody(required = false) Long guestId, @PathVariable(name = "book-id") Long bookId) {
         if (Objects.nonNull(userId)) {
             cartService.removeProductFromCart(userId, bookId);
-            return cartService.getCartItemInfos(userId);
+        } else {
+            cartService.removeProductFromCart(guestId, bookId);
         }
-        cartService.removeProductFromCart(guestId, bookId);
-        return cartService.getCartItemInfos(guestId);
     }
 
 

--- a/src/main/java/shop/wannab/order_payment_service/controller/OrderController.java
+++ b/src/main/java/shop/wannab/order_payment_service/controller/OrderController.java
@@ -22,7 +22,7 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping
-    public OrderPageRequestDto getNecesaryOrderInfo(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestBody Long guestId, @RequestBody OrderItemListDto orderItemListDto) {
+    public OrderPageRequestDto getNecesaryOrderInfo(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestParam Long guestId, @RequestBody OrderItemListDto orderItemListDto) {
         try {
             bookClient.validateOrderItems(orderItemListDto);
         } catch (FeignException.BadRequest e) {
@@ -37,7 +37,7 @@ public class OrderController {
 
 
     @PostMapping("/orders/new")
-    OrderInfoForPayment processOrder(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestBody Long guestId, @RequestBody OrderSubmitDto orderSubmitDto) {
+    OrderInfoForPayment processOrder(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestParam Long guestId, @RequestBody OrderSubmitDto orderSubmitDto) {
         if (Objects.nonNull(userId)) {
             return orderService.createOrder(orderSubmitDto, userId);
         }

--- a/src/main/java/shop/wannab/order_payment_service/entity/Cart.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/Cart.java
@@ -1,0 +1,26 @@
+package shop.wannab.order_payment_service.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "cart")
+@Getter
+@Setter
+public class Cart {
+    @Id
+    private Long userId; // 유저 ID가 곧 Cart ID
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<CartItemEntity> items = new ArrayList<>();
+
+    public void addItem(CartItemEntity item) {
+        item.setCart(this);
+        this.items.add(item);
+    }
+
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/CartItemEntity.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/CartItemEntity.java
@@ -1,0 +1,31 @@
+package shop.wannab.order_payment_service.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "cart_item")
+@Getter
+@NoArgsConstructor
+public class CartItemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long bookId;
+
+    private int quantity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_user_id")
+    @Setter
+    private Cart cart;
+
+    public CartItemEntity(Long bookId, int quantity) {
+        this.bookId = bookId;
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/CartItem.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/CartItem.java
@@ -1,4 +1,4 @@
-package shop.wannab.order_payment_service.entity;
+package shop.wannab.order_payment_service.entity.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderDetailResponse.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderDetailResponse.java
@@ -2,7 +2,7 @@ package shop.wannab.order_payment_service.entity.dto;
 
 
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
+
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -14,15 +14,9 @@ import shop.wannab.order_payment_service.entity.OrderStatus;
 public class OrderDetailResponse {
 
     private final List<OrderBookDetailResponse> books;
-
     private final Long orderNumber;          //주문번호 (일단 orderid그대로)
     private final LocalDateTime orderAt;       //주문일시
-    private final LocalDateTime paymentAt;     //결제일시
-    //private final String deliveryMethod;       //배송방법 (굳이 있어야할까?)
     private final OrderStatus orderStatus;     //주문상태
-    //private final String carrierName;          //택배사인데 빼도될거같기도
-    private final String deliveryNumber;       //송장번호
-
     private final int totalPrice;           //총 주문금액
 
 

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderItemListDto.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderItemListDto.java
@@ -3,7 +3,6 @@ package shop.wannab.order_payment_service.entity.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import shop.wannab.order_payment_service.entity.CartItem;
 
 import java.util.List;
 

--- a/src/main/java/shop/wannab/order_payment_service/repository/CartItemRepository.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/CartItemRepository.java
@@ -1,0 +1,8 @@
+package shop.wannab.order_payment_service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.wannab.order_payment_service.entity.CartItemEntity;
+
+public interface CartItemRepository extends JpaRepository<CartItemEntity, Long> {
+
+}

--- a/src/main/java/shop/wannab/order_payment_service/repository/CartRedisRepository.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/CartRedisRepository.java
@@ -1,78 +1,18 @@
 package shop.wannab.order_payment_service.repository;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Repository;
-import shop.wannab.order_payment_service.entity.CartItem;
+import shop.wannab.order_payment_service.entity.dto.CartItem;
 
-import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
-import static shop.wannab.order_payment_service.constants.Constants.GUEST_CART_TTL;
+public interface CartRedisRepository {
+    List<CartItem> getCartItems(Long userIdentifier);
 
-@RequiredArgsConstructor
-@Repository
-public class CartRedisRepository implements CartRepository {
-    private static final long CART_DUMMY_KEY = -1;
-    private static final long CART_DUMMY_VAL = -1;
+    void addItemToCart(Long userIdentifier, long bookId);
 
-    private final RedisTemplate<String, Object> redisTemplate;
-    private static final String CART_KEY_PREFIX = "cart:";
+    void updateItemQuantity(Long userIdentifier, long bookId, int quantity);
 
-    @Override
-    public List<CartItem> getCartItems(Long userIdentifier) {
-        List<CartItem> cartItems = new ArrayList<>();
-        if (Objects.isNull(userIdentifier)) {
-            return cartItems;
-        }
-        String cartKey = CART_KEY_PREFIX + userIdentifier;
-        Map<Long, Integer> cartBooks = redisTemplate.<Long, Integer>opsForHash().entries(cartKey); //key: bookId, value: quantity
+    void removeItemFromCart(Long userIdentifier, long bookId);
 
-        for (Map.Entry<Long, Integer> entry : cartBooks.entrySet()) {
-            CartItem item = new CartItem(entry.getKey(), entry.getValue());
-            cartItems.add(item);
-        }
-        return cartItems;
-    }
-
-    @Override
-    public void addItemToCart(Long userIdentifier, long bookId) {
-        String cartKey = CART_KEY_PREFIX + userIdentifier;
-        redisTemplate.opsForHash().increment(cartKey, bookId, 1);
-    }
-
-    @Override
-    public void updateItemQuantity(Long userIdentifier, long bookId, int quantity) {
-        String cartKey = CART_KEY_PREFIX + userIdentifier;
-        redisTemplate.opsForHash().put(cartKey, bookId, quantity);
-    }
-
-    @Override
-    public void removeItemFromCart(Long userIdentifier, long bookId) {
-        String cartKey = CART_KEY_PREFIX + userIdentifier;
-        redisTemplate.opsForHash().delete(cartKey, bookId);
-    }
-
-    @Override
-    public void createCart(Long userIdentifier) {
-        String cartKey;
-        if (isGuest(userIdentifier)) {
-            String guest = "guest:" + userIdentifier;
-            cartKey = CART_KEY_PREFIX + guest; //cart:guest:-142435
-
-            redisTemplate.opsForHash().put(cartKey, CART_DUMMY_KEY, CART_DUMMY_VAL);
-            redisTemplate.expire(cartKey, Duration.ofHours(GUEST_CART_TTL));
-            return;
-        }
-        cartKey = CART_KEY_PREFIX + userIdentifier;
-        redisTemplate.opsForHash().put(cartKey, CART_DUMMY_KEY, CART_DUMMY_VAL);
-    }
-
-    private boolean isGuest(long userIdentifier) {
-        return userIdentifier < 0;
-    }
+    void createCart(Long userIdentifier);
 
 }

--- a/src/main/java/shop/wannab/order_payment_service/repository/CartRedisRepositoryImpl.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/CartRedisRepositoryImpl.java
@@ -1,0 +1,78 @@
+package shop.wannab.order_payment_service.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import shop.wannab.order_payment_service.entity.dto.CartItem;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static shop.wannab.order_payment_service.constants.Constants.GUEST_CART_TTL;
+
+@RequiredArgsConstructor
+@Repository
+public class CartRedisRepositoryImpl implements CartRedisRepository {
+    private static final long CART_DUMMY_KEY = -1;
+    private static final long CART_DUMMY_VAL = -1;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String CART_KEY_PREFIX = "cart:";
+
+    @Override
+    public List<CartItem> getCartItems(Long userIdentifier) {
+        List<CartItem> cartItems = new ArrayList<>();
+        if (Objects.isNull(userIdentifier)) {
+            return cartItems;
+        }
+        String cartKey = CART_KEY_PREFIX + userIdentifier;
+        Map<Long, Integer> cartBooks = redisTemplate.<Long, Integer>opsForHash().entries(cartKey); //key: bookId, value: quantity
+
+        for (Map.Entry<Long, Integer> entry : cartBooks.entrySet()) {
+            CartItem item = new CartItem(entry.getKey(), entry.getValue());
+            cartItems.add(item);
+        }
+        return cartItems;
+    }
+
+    @Override
+    public void addItemToCart(Long userIdentifier, long bookId) {
+        String cartKey = CART_KEY_PREFIX + userIdentifier;
+        redisTemplate.opsForHash().increment(cartKey, bookId, 1);
+    }
+
+    @Override
+    public void updateItemQuantity(Long userIdentifier, long bookId, int quantity) {
+        String cartKey = CART_KEY_PREFIX + userIdentifier;
+        redisTemplate.opsForHash().put(cartKey, bookId, quantity);
+    }
+
+    @Override
+    public void removeItemFromCart(Long userIdentifier, long bookId) {
+        String cartKey = CART_KEY_PREFIX + userIdentifier;
+        redisTemplate.opsForHash().delete(cartKey, bookId);
+    }
+
+    @Override
+    public void createCart(Long userIdentifier) {
+        String cartKey;
+        if (isGuest(userIdentifier)) {
+            String guest = "guest:" + userIdentifier;
+            cartKey = CART_KEY_PREFIX + guest; //cart:guest:-142435
+
+            redisTemplate.opsForHash().put(cartKey, CART_DUMMY_KEY, CART_DUMMY_VAL);
+            redisTemplate.expire(cartKey, Duration.ofHours(GUEST_CART_TTL));
+            return;
+        }
+        cartKey = CART_KEY_PREFIX + userIdentifier;
+        redisTemplate.opsForHash().put(cartKey, CART_DUMMY_KEY, CART_DUMMY_VAL);
+    }
+
+    private boolean isGuest(long userIdentifier) {
+        return userIdentifier < 0;
+    }
+
+}

--- a/src/main/java/shop/wannab/order_payment_service/repository/CartRepository.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/CartRepository.java
@@ -1,18 +1,9 @@
 package shop.wannab.order_payment_service.repository;
 
-import shop.wannab.order_payment_service.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.wannab.order_payment_service.entity.Cart;
 
-import java.util.List;
+public interface CartRepository extends JpaRepository<Cart, Long>, CartRedisRepository {
 
-public interface CartRepository {
-    List<CartItem> getCartItems(Long userIdentifier);
-
-    void addItemToCart(Long userIdentifier, long bookId);
-
-    void updateItemQuantity(Long userIdentifier, long bookId, int quantity);
-
-    void removeItemFromCart(Long userIdentifier, long bookId);
-
-    void createCart(Long userIdentifier);
 
 }

--- a/src/main/java/shop/wannab/order_payment_service/repository/OrderRepository.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/OrderRepository.java
@@ -1,6 +1,5 @@
 package shop.wannab.order_payment_service.repository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -9,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import shop.wannab.order_payment_service.entity.Order;
 import shop.wannab.order_payment_service.entity.OrderStatus;
 
-public interface OrderReopsitory extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long> {
 
     //주문목록조회 (회원)
     Page<Order> findAllByUserId(Long userId, Pageable pageable);

--- a/src/main/java/shop/wannab/order_payment_service/scheduler/CartBackupScheduler.java
+++ b/src/main/java/shop/wannab/order_payment_service/scheduler/CartBackupScheduler.java
@@ -1,0 +1,55 @@
+package shop.wannab.order_payment_service.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import shop.wannab.order_payment_service.entity.Cart;
+import shop.wannab.order_payment_service.entity.CartItemEntity;
+import shop.wannab.order_payment_service.entity.dto.CartItem;
+import shop.wannab.order_payment_service.repository.CartRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+@Component
+@RequiredArgsConstructor
+public class CartBackupScheduler {
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(4);
+    private final Map<Long, Boolean> userScheduledMap = new ConcurrentHashMap<>();
+    private final CartRepository cartRepository;
+
+    public void onCartChanged(Long userid) {
+        if (userScheduledMap.putIfAbsent(userid, true) != null) {
+            return;
+        }
+
+        scheduler.schedule(()-> {
+            try {
+                writeBackCart(userid);
+            } finally {
+                userScheduledMap.remove(userid);
+            }
+        }, 5, TimeUnit.MINUTES);
+    }
+
+    private void writeBackCart(Long userId) {
+        List<CartItem> redisCartItems = cartRepository.getCartItems(userId);
+        if (redisCartItems.isEmpty()) {
+            return;
+        }
+        Cart cart = new Cart();
+        cart.setUserId(userId);
+
+        for (CartItem cartItem : redisCartItems) {
+            CartItemEntity entity = new CartItemEntity(cartItem.getBookId(), cartItem.getQuantity());
+            cart.addItem(entity);
+        }
+
+        cartRepository.save(cart);
+    }
+
+}

--- a/src/main/java/shop/wannab/order_payment_service/scheduler/OrderStatusScheduler.java
+++ b/src/main/java/shop/wannab/order_payment_service/scheduler/OrderStatusScheduler.java
@@ -8,20 +8,20 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import shop.wannab.order_payment_service.entity.Order;
 import shop.wannab.order_payment_service.entity.OrderStatus;
-import shop.wannab.order_payment_service.repository.OrderReopsitory;
+import shop.wannab.order_payment_service.repository.OrderRepository;
 
 @Component
 @RequiredArgsConstructor
 public class OrderStatusScheduler {
 
-    private final OrderReopsitory orderReopsitory;
+    private final OrderRepository orderRepository;
 
     // 매 1분마다 실행 (배송 시작 1일 후 자동 완료)
     @Scheduled(fixedDelay = 60 * 1000) // TODO: 테스트하려고 1분으로 설정해둠 (추후에 변경필요)
     @Transactional
     public void completeShippedOrders() {
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(1);
-        List<Order> shippingOrders = orderReopsitory.findByOrderStatusAndShippedAtBefore(OrderStatus.SHIPPING, threshold);
+        List<Order> shippingOrders = orderRepository.findByOrderStatusAndShippedAtBefore(OrderStatus.SHIPPING, threshold);
 
         for (Order order : shippingOrders) {
             order.setOrderStatus(OrderStatus.COMPLETED);

--- a/src/main/java/shop/wannab/order_payment_service/service/CartService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/CartService.java
@@ -10,16 +10,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.wannab.order_payment_service.client.BookClient;
-import shop.wannab.order_payment_service.entity.CartItem;
+import shop.wannab.order_payment_service.entity.dto.CartItem;
 import shop.wannab.order_payment_service.entity.dto.OrderBookInfoListDto;
 import shop.wannab.order_payment_service.entity.dto.OrderItemListDto;
 import shop.wannab.order_payment_service.repository.CartRepository;
+import shop.wannab.order_payment_service.scheduler.CartBackupScheduler;
 
 @Service
 @RequiredArgsConstructor
 public class CartService {
     private final BookClient bookClient;
     private final CartRepository cartRepository;
+    private final CartBackupScheduler cartBackupScheduler;
 
     @Transactional(readOnly = true)
     public OrderBookInfoListDto getCartItemInfos(Long userIdentifier) {
@@ -30,16 +32,19 @@ public class CartService {
     @Transactional
     public void addCartItem(Long userIdentifier, long bookId) {
         cartRepository.addItemToCart(userIdentifier, bookId);
+        cartBackupScheduler.onCartChanged(userIdentifier);
     }
 
     @Transactional
     public void updateItemQuantity(Long userIdentifier, long bookId, int quantity) {
         cartRepository.updateItemQuantity(userIdentifier, bookId, quantity);
+        cartBackupScheduler.onCartChanged(userIdentifier);
     }
 
     @Transactional
     public void removeProductFromCart(Long userIdentifier, long bookId) {
         cartRepository.removeItemFromCart(userIdentifier, bookId);
+        cartBackupScheduler.onCartChanged(userIdentifier);
     }
 
     public Cookie createCart(Long userIdentifier) {

--- a/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
@@ -22,7 +22,7 @@ import shop.wannab.order_payment_service.entity.dto.*;
 
 import shop.wannab.order_payment_service.repository.GuestRepository;
 import shop.wannab.order_payment_service.repository.OrderBookRepository;
-import shop.wannab.order_payment_service.repository.OrderReopsitory;
+import shop.wannab.order_payment_service.repository.OrderRepository;
 import shop.wannab.order_payment_service.repository.WrappingPaperRepository;
 import shop.wannab.order_payment_service.service.Impl.OrderEmailHelper;
 
@@ -37,7 +37,7 @@ public class OrderService {
     private final PaymentService paymentService;
     private final CouponClient couponClient;
 
-    private final OrderReopsitory orderReopsitory;
+    private final OrderRepository orderRepository;
     private final GuestRepository guestRepository;
     private final OrderBookRepository orderBookRepository;
     private final WrappingPaperRepository wrappingPaperRepository;
@@ -113,7 +113,7 @@ public class OrderService {
                 orderSubmitDto.getRecipientPhoneNumber(),
                 orderSubmitDto.getRecipientAddress());
 
-        order = orderReopsitory.save(order);
+        order = orderRepository.save(order);
 
         //------- Order_book table record add -------//
         List<OrderBook> orderBooks = new ArrayList<>();
@@ -274,7 +274,7 @@ public class OrderService {
     public Page<OrderLookupResponse> getOrdersByUser(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("orderAt").descending());
 
-        return orderReopsitory.findAllByUserId(userId, pageable)
+        return orderRepository.findAllByUserId(userId, pageable)
                 .map(order -> new OrderLookupResponse(
                         order.getId(),
                         order.getOrderName(),
@@ -300,7 +300,7 @@ public class OrderService {
         // 주문자 id나 이름도 띄우면 좋을듯
         // -> 비회원이면 이메일 띄우고
 
-        return orderReopsitory.findAll(pageable)
+        return orderRepository.findAll(pageable)
                 .map(order -> new OrderLookupResponse(
                         order.getId(),
                         order.getOrderName(),
@@ -348,9 +348,7 @@ public class OrderService {
                 bookDetails,
                 order.getId(),
                 order.getOrderAt(),
-                order.getOrderAt(), // TODO: 결제일시로 바꾸기
                 order.getOrderStatus(),
-                order.getId().toString(), // 송장번호 = 주문번호(임시)
                 order.getTotalPrice()
         );
     }
@@ -358,7 +356,7 @@ public class OrderService {
     //주문상세조회 (회원)
     @Transactional(readOnly = true)
     public OrderDetailResponse getOrder(Long orderId, Long userId) {
-        Order order = orderReopsitory.findById(orderId).orElseThrow(() -> new IllegalArgumentException("주문정보없음"));
+        Order order = orderRepository.findById(orderId).orElseThrow(() -> new IllegalArgumentException("주문정보없음"));
 
         // 본인만 조회할수있도록
         if (!userId.equals(order.getUserId())) {
@@ -371,7 +369,7 @@ public class OrderService {
     //주문상세조회 (비회원)
     @Transactional(readOnly = true)
     public OrderDetailResponse getOrderForGuest(Long orderId, String password) {
-        Order order = orderReopsitory.findById(orderId)
+        Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
 
         Guest guest = guestRepository.findByOrder_Id(orderId)
@@ -388,7 +386,7 @@ public class OrderService {
     @Transactional
     public void cancelOrder(Long orderId, Long userId){
 
-        Order order = orderReopsitory.findById(orderId).orElseThrow(() -> new IllegalArgumentException("주문번호를 찾을수 없음"));
+        Order order = orderRepository.findById(orderId).orElseThrow(() -> new IllegalArgumentException("주문번호를 찾을수 없음"));
 
         // 본인만 취소할수있도록 검사
         if (!userId.equals(order.getUserId())) {
@@ -415,7 +413,7 @@ public class OrderService {
     //주문취소(결제취소) 비회원 -> 비회원은 order에 따로 userId가 없어서 조회하는것처럼 주문번호와 패스워드를 사용해서 주문취소
     @Transactional
     public void cancelGuestOrder(Long orderId, String password){
-        Order order = orderReopsitory.findById(orderId)
+        Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
 
         Guest guest = guestRepository.findByOrder_Id(orderId)
@@ -454,7 +452,7 @@ public class OrderService {
     //주문상태변경 (관리자)
     @Transactional
     public void updateStatus(Long userId, Long orderId, OrderStatus newStatus){
-        Order order = orderReopsitory.findById(orderId).orElseThrow(() -> new IllegalArgumentException("주문번호를 찾을수 없음"));
+        Order order = orderRepository.findById(orderId).orElseThrow(() -> new IllegalArgumentException("주문번호를 찾을수 없음"));
 
 //        // ADMIN 확인
 //        String role = userClient.getUserRole(userId);
@@ -476,7 +474,7 @@ public class OrderService {
     //반품 (회원)
     @Transactional
     public void refundOrder(Long userId, Long orderId, RefundReason reason){
-        Order order = orderReopsitory.findById(orderId)
+        Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다"));
 
         // 본인만 반품할수있도록 검사
@@ -519,7 +517,7 @@ public class OrderService {
     //반품(비회원)
     @Transactional
     public void refundGuestOrder(Long orderId, String password, RefundReason reason){
-        Order order = orderReopsitory.findById(orderId)
+        Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
 
         Guest guest = guestRepository.findByOrder_Id(orderId)

--- a/src/main/java/shop/wannab/order_payment_service/service/PaymentService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/PaymentService.java
@@ -15,7 +15,7 @@ import shop.wannab.order_payment_service.entity.payment.dto.FinalOrderResultDto;
 import shop.wannab.order_payment_service.entity.payment.dto.TossConfirmRequestDto;
 import shop.wannab.order_payment_service.entity.payment.dto.TossConfirmResponseDto;
 import shop.wannab.order_payment_service.repository.CancelRepository;
-import shop.wannab.order_payment_service.repository.OrderReopsitory;
+import shop.wannab.order_payment_service.repository.OrderRepository;
 import shop.wannab.order_payment_service.repository.PaymentRepository;
 
 @Service
@@ -24,7 +24,7 @@ public class PaymentService {
 
     private final TossPaymentsApiClient tossPaymentsApiClient;
     private final PaymentRepository paymentRepository;
-    private final OrderReopsitory orderRepository;
+    private final OrderRepository orderRepository;
     private final CancelRepository cancelRepository;
 
     @Value("${toss.payments.secretKey}")


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

레디스에서만 저장되고있던 장바구니를 write-back 전략을 사용하여 데이터베이스에 저장합니다.


## 🔎 작업 상세 내용

- [x] 카트관련 엔티티 생성
- [x] 레디스 장바구니 항목 변화시 5분후 레디스 장바구니 항목 db적용 기능 구현 ( 5분내에 변화가 또 생겨도 저장시점 밀리지 않음)
- [x] 기타 수정

## ⏰ Pull Request 마감시간
> 7.2.18h

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #79 
