### PR TITLE
Feature/issue 98/when order failed

### DIFF
--- a/src/main/java/shop/wannab/order_payment_service/client/CouponClient.java
+++ b/src/main/java/shop/wannab/order_payment_service/client/CouponClient.java
@@ -9,7 +9,7 @@ import shop.wannab.order_payment_service.entity.dto.*;
 
 import java.util.List;
 
-@FeignClient(name = "wannab-coupon-service")
+@FeignClient(name = "coupon-service")
 public interface CouponClient {
 
     @PostMapping("/api/coupons/order")

--- a/src/main/java/shop/wannab/order_payment_service/entity/Order.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/Order.java
@@ -84,7 +84,9 @@ public class Order {
         this.shippedAt = shippedAt;
         this.orderStatus = OrderStatus.PENDING;
         this.deliveryWant = deliveryRequestAt;
-        this.userId = userId;
+        if (userId > 0) {
+            this.userId = userId;
+        }
         this.totalBookPrice = totalBookPrice;
         this.totalDiscountAmount = totalDiscountAmount;
         this.shippingFee = shippingFee;

--- a/src/main/java/shop/wannab/order_payment_service/entity/OrderStatus.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/OrderStatus.java
@@ -2,9 +2,11 @@ package shop.wannab.order_payment_service.entity;
 
 
 public enum OrderStatus {
-    PENDING, //대기
+    PENDING, //결제대기
+    PAID,   // 결제완료(배송대기)
     SHIPPING, //배송중
     COMPLETED, //완료
     RETURNED, //반품
-    CANCELLED; //주문취소
+    CANCELLED, //주문취소
+    FAILED; //주문실패
 }

--- a/src/main/java/shop/wannab/order_payment_service/repository/OrderRepository.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/OrderRepository.java
@@ -17,4 +17,10 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderQueryR
 
     //배송중으로 변경뒤 일정시간 지난후 배송완료로 변경
     List<Order> findByOrderStatusAndShippedAtBefore(OrderStatus status, LocalDateTime shippedAtBefore);
+
+    //failed 필터후 주문목록조회
+    Page<Order> findAllByUserIdAndOrderStatusNot(Long userId, OrderStatus status, Pageable pageable);
+
+    //대기후 결제가 되지않으면 주문상태를 FAILED로 변환
+    List<Order> findByOrderStatusAndOrderAtBefore(OrderStatus status, LocalDateTime threshold);
 }

--- a/src/main/java/shop/wannab/order_payment_service/repository/OrderRepository.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/OrderRepository.java
@@ -1,10 +1,13 @@
 package shop.wannab.order_payment_service.repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import shop.wannab.order_payment_service.entity.Order;
 import shop.wannab.order_payment_service.entity.OrderStatus;
 import shop.wannab.order_payment_service.repository.query.OrderQueryRepository;
@@ -23,4 +26,17 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderQueryR
 
     //대기후 결제가 되지않으면 주문상태를 FAILED로 변환
     List<Order> findByOrderStatusAndOrderAtBefore(OrderStatus status, LocalDateTime threshold);
+
+
+    //원하는 배송희망날짜에 출고
+    @Query("SELECT o FROM Order o WHERE o.orderStatus = 'PAID' AND o.deliveryWant = :today")
+    List<Order> findPaidOrdersWithTodayDelivery(@Param("today") LocalDate today);
+    //원하는 출고날이 주말이라면 금요일에 처리
+    @Query("SELECT o FROM Order o WHERE o.orderStatus = 'PAID' AND o.deliveryWant IN (:today, :saturday, :sunday)")
+    List<Order> findPaidOrdersWithDeliveryWantIn(@Param("today") LocalDate today,
+                                                 @Param("saturday") LocalDate saturday,
+                                                 @Param("sunday") LocalDate sunday);
+    //원하는 배송희망날짜가 Null일시
+    @Query("SELECT o FROM Order o WHERE o.orderStatus = 'PAID' AND o.deliveryWant IS NULL")
+    List<Order> findPaidOrdersWithNoDeliveryWant();
 }

--- a/src/main/java/shop/wannab/order_payment_service/scheduler/OrderStatusScheduler.java
+++ b/src/main/java/shop/wannab/order_payment_service/scheduler/OrderStatusScheduler.java
@@ -1,6 +1,9 @@
 package shop.wannab.order_payment_service.scheduler;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +21,10 @@ public class OrderStatusScheduler {
 
     private final OrderRepository orderRepository;
 
-    // 매 1분마다 실행 (배송 시작 1일 후 자동 완료)
+
+    /**
+     * 출고된 후 일정시간 후 배송완료처리(배송 시작 1분 후 자동 완료)
+     */
     @Scheduled(fixedDelay = 60 * 1000) // TODO: 테스트하려고 1분으로 설정해둠 (추후에 변경필요)
     @Transactional
     public void completeShippedOrders() {
@@ -30,7 +36,9 @@ public class OrderStatusScheduler {
         }
     }
 
-
+    /**
+     * 주문생성후 1분내로 결제하지 않으면 주문실패처리
+     */
     @Scheduled(fixedDelay = 60 * 1000) // 1분마다 실행
     @Transactional
     public void markFailedOrders() {
@@ -40,6 +48,39 @@ public class OrderStatusScheduler {
         for (Order order : expiredOrders) {
             order.setOrderStatus(OrderStatus.FAILED);
             log.info("결제 실패로 전환된 주문: id={}, 생성시각={}", order.getId(), order.getOrderAt());
+        }
+    }
+
+    /**
+     * 출고정책
+     */
+    @Scheduled(cron = "0 0 15 * * MON-FRI")
+    @Transactional
+    public void updateOrdersToShipping() {
+        LocalDate today = LocalDate.now();
+        DayOfWeek day = today.getDayOfWeek();
+
+        List<Order> ordersToShip = new ArrayList<>();
+
+        if (day == DayOfWeek.FRIDAY) {
+            // 배송희망일이 주말인경우 금요일에 전부 출고
+            LocalDate saturday = today.plusDays(1);
+            LocalDate sunday = today.plusDays(2);
+            ordersToShip.addAll(orderRepository.findPaidOrdersWithDeliveryWantIn(today, saturday, sunday));
+        } else {
+            // 배송희망일이 오늘인 주문
+            ordersToShip.addAll(orderRepository.findPaidOrdersWithTodayDelivery(today));
+        }
+
+        // 배송희망일이 null인 경우는 전부 월요일에 출고
+        if (day == DayOfWeek.MONDAY) {
+            ordersToShip.addAll(orderRepository.findPaidOrdersWithNoDeliveryWant());
+        }
+
+        for (Order order : ordersToShip) {
+            order.setOrderStatus(OrderStatus.SHIPPING);
+            order.setShippedAt(LocalDateTime.now());
+            log.info("주문 {} 출고 처리됨 (배송희망일: {})", order.getId(), order.getDeliveryWant());
         }
     }
 }

--- a/src/main/java/shop/wannab/order_payment_service/scheduler/OrderStatusScheduler.java
+++ b/src/main/java/shop/wannab/order_payment_service/scheduler/OrderStatusScheduler.java
@@ -3,6 +3,7 @@ package shop.wannab.order_payment_service.scheduler;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +13,7 @@ import shop.wannab.order_payment_service.repository.OrderRepository;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class OrderStatusScheduler {
 
     private final OrderRepository orderRepository;
@@ -25,6 +27,19 @@ public class OrderStatusScheduler {
 
         for (Order order : shippingOrders) {
             order.setOrderStatus(OrderStatus.COMPLETED);
+        }
+    }
+
+
+    @Scheduled(fixedDelay = 60 * 1000) // 1분마다 실행
+    @Transactional
+    public void markFailedOrders() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(1);
+        List<Order> expiredOrders = orderRepository.findByOrderStatusAndOrderAtBefore(OrderStatus.PENDING, threshold);
+
+        for (Order order : expiredOrders) {
+            order.setOrderStatus(OrderStatus.FAILED);
+            log.info("결제 실패로 전환된 주문: id={}, 생성시각={}", order.getId(), order.getOrderAt());
         }
     }
 }

--- a/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
@@ -106,7 +106,8 @@ public class OrderService {
         String orderName = createOrderName(bookSimpleInfos.getIdTitlePriceDtos().get(0).getTitle(), bookIds.size());
         Order order = new Order(userId,
                 orderName,
-                getShippingDate(),
+//                getShippingDate(),
+                null,
                 orderSubmitDto.getDeliveryRequestAt(),
                 totalBookPrice, totalDiscountAmount,
                 shippingFee,
@@ -200,23 +201,23 @@ public class OrderService {
         return totalWrappingPaperPrice;
     }
 
-    private LocalDateTime getShippingDate() { //출고일 정책
-        LocalDateTime now = LocalDateTime.now();
-
-        // 15시 이후면 다음 날로
-        if (now.toLocalTime().isAfter(LocalTime.of(15, 0))) {
-            now = now.plusDays(1);
-        }
-
-        LocalDate date = now.toLocalDate();
-
-        // 주말이면 월요일까지 이동
-        while (date.getDayOfWeek() == DayOfWeek.SATURDAY ||
-               date.getDayOfWeek() == DayOfWeek.SUNDAY) {
-            now = date.plusDays(1).atStartOfDay();
-        }
-        return now;
-    }
+//    private LocalDateTime getShippingDate() { //출고일 정책
+//        LocalDateTime now = LocalDateTime.now();
+//
+//        // 15시 이후면 다음 날로
+//        if (now.toLocalTime().isAfter(LocalTime.of(15, 0))) {
+//            now = now.plusDays(1);
+//        }
+//
+//        LocalDate date = now.toLocalDate();
+//
+//        // 주말이면 월요일까지 이동
+//        while (date.getDayOfWeek() == DayOfWeek.SATURDAY ||
+//               date.getDayOfWeek() == DayOfWeek.SUNDAY) {
+//            now = date.plusDays(1).atStartOfDay();
+//        }
+//        return now;
+//    }
 
     private String createOrderName(String oneOfBookTitle, int orderItemCount) {
         if (orderItemCount > 1) {
@@ -279,7 +280,7 @@ public class OrderService {
     public Page<OrderLookupResponse> getOrdersByUser(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("orderAt").descending());
 
-        return orderRepository.findAllByUserId(userId, pageable)
+        return orderRepository.findAllByUserIdAndOrderStatusNot(userId, OrderStatus.FAILED, pageable)
                 .map(order -> new OrderLookupResponse(
                         order.getId(),
                         order.getOrderName(),
@@ -388,8 +389,8 @@ public class OrderService {
             throw new IllegalArgumentException("본인 주문만 취소가능");
         }
 
-        // PENDING(대기)에서만 취소가능
-        if (order.getOrderStatus() != OrderStatus.PENDING) {
+        // PAID(대기)에서만 취소가능
+        if (order.getOrderStatus() != OrderStatus.PAID) {
             throw new IllegalStateException("현재 주문 상태에서는 취소할 수 없습니다: " + order.getOrderStatus());
         }
 
@@ -418,8 +419,8 @@ public class OrderService {
             throw new IllegalArgumentException("주문번호 또는 비밀번호가 일치하지 않습니다.");
         }
 
-        // PENDING(대기)에서만 취소가능
-        if (order.getOrderStatus() != OrderStatus.PENDING) {
+        // PAID(대기)에서만 취소가능
+        if (order.getOrderStatus() != OrderStatus.PAID) {
             throw new IllegalStateException("현재 주문 상태에서는 취소할 수 없습니다: " + order.getOrderStatus());
         }
         order.setOrderStatus(OrderStatus.CANCELLED);

--- a/src/main/java/shop/wannab/order_payment_service/service/PaymentService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/PaymentService.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.wannab.order_payment_service.client.TossPaymentsApiClient;
+import shop.wannab.order_payment_service.entity.Order;
+import shop.wannab.order_payment_service.entity.OrderStatus;
 import shop.wannab.order_payment_service.entity.payment.Cancel;
 import shop.wannab.order_payment_service.entity.payment.Payment;
 import shop.wannab.order_payment_service.entity.payment.dto.FinalOrderResultDto;
@@ -35,44 +37,56 @@ public class PaymentService {
         String encodedAuth = Base64.getEncoder().encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
         String authHeader = "Basic " + encodedAuth;
 
-        TossConfirmResponseDto tossResponse = tossPaymentsApiClient.confirmPayment(authHeader, requestDto);
-
-        if (tossResponse.getTotalAmount() != requestDto.getAmount()) {
-            throw new IllegalStateException("결제 금액이 일치하지 않습니다.");
-        }
-
 //      TODO: 주문 정보 조회 및 상태 변경
 //      왜 이렇게 파싱하냐면 토스페이먼츠 API에 orderId를 보낼때 최소 6자이상 String 타입을 보내야해서 붙였습니다
 //      그래서 아래에 파싱한 orderId로 OrderRepository에서 값 변경하시거나 활용할때 사용하시면 될거같습니다.
         Long orderId = Long.parseLong(requestDto.getOrderId().replace("testWannaB", ""));
-        LocalDateTime approvedAt = null;
-        if (tossResponse.getApprovedAt() != null && !tossResponse.getApprovedAt().isEmpty()) {
-            approvedAt = OffsetDateTime.parse(tossResponse.getApprovedAt()).toLocalDateTime();
+        Order order = orderRepository.findById(orderId).orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+
+        try{
+            TossConfirmResponseDto tossResponse = tossPaymentsApiClient.confirmPayment(authHeader, requestDto);
+
+            if (tossResponse.getTotalAmount() != requestDto.getAmount()) {
+                throw new IllegalStateException("결제 금액이 일치하지 않습니다.");
+            }
+
+
+            LocalDateTime approvedAt = null;
+            if (tossResponse.getApprovedAt() != null && !tossResponse.getApprovedAt().isEmpty()) {
+                approvedAt = OffsetDateTime.parse(tossResponse.getApprovedAt()).toLocalDateTime();
+            }
+            LocalDateTime requestedAt = OffsetDateTime.parse(tossResponse.getRequestedAt()).toLocalDateTime();
+
+            // 4. Payment 객체 생성
+            Payment payment = new Payment(
+                    tossResponse.getPaymentKey(),
+                    tossResponse.getType(),
+                    tossResponse.getMethod(),
+                    tossResponse.getTotalAmount(),
+                    tossResponse.getBalanceAmount(),
+                    tossResponse.getStatus(),
+                    requestedAt,
+                    approvedAt,
+                    orderRepository.findById(orderId).orElse(null)
+            );
+
+            // 5. DB에 Payment 정보 저장
+            paymentRepository.save(payment);
+
+            //결제완료시 orderStatus 결제완료로 변환
+            order.setOrderStatus(OrderStatus.PAID);
+
+            // 6. 프론트 서비스에 전달할 최종 결과 DTO 생성 및 반환
+            return new FinalOrderResultDto(
+                    tossResponse.getPaymentKey(),
+                    tossResponse.getOrderId(),
+                    tossResponse.getTotalAmount()
+            );
+        }catch (Exception e){
+            order.setOrderStatus(OrderStatus.FAILED);
+            throw e;
         }
-        LocalDateTime requestedAt = OffsetDateTime.parse(tossResponse.getRequestedAt()).toLocalDateTime();
 
-        // 4. Payment 객체 생성
-        Payment payment = new Payment(
-                tossResponse.getPaymentKey(),
-                tossResponse.getType(),
-                tossResponse.getMethod(),
-                tossResponse.getTotalAmount(),
-                tossResponse.getBalanceAmount(),
-                tossResponse.getStatus(),
-                requestedAt,
-                approvedAt,
-                orderRepository.findById(orderId).orElse(null)
-        );
-
-        // 5. DB에 Payment 정보 저장
-        paymentRepository.save(payment);
-
-        // 6. 프론트 서비스에 전달할 최종 결과 DTO 생성 및 반환
-        return new FinalOrderResultDto(
-                tossResponse.getPaymentKey(),
-                tossResponse.getOrderId(),
-                tossResponse.getTotalAmount()
-        );
     }
 
     @Transactional


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

> 결제실패시 주문상태 처리, Feign URL수정, Entity 수정, 출고정책스케줄러 로직 추가

## 🔎 작업 상세 내용

- [x] 주문이 생성되고 1분(임의설정)내로 결제를 안하거나 결제도중 실패시 주문실패(FAILED) 상태로 주문상태변경
- [x] 비회원 주문생성시 userId null로 설정(딱히 저장될 필요가없음), 쿠폰 feign client URL수정
- [x] 배송희망날짜 지정시 희망날짜의 15:00에 출고되고 지정하지않을시 매주 월요일 15:00출고, 단 희망날짜가 주말일시 그 주 금요일에 같이출고
      
## ⏰ Pull Request 마감시간
> 17:00

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #99
Closes #98 
