### PR TITLE
112: 주문페이지 생성에 필요한 orderItemListDto 가져오는 방식 변경

### DIFF
--- a/src/main/java/shop/wannab/order_payment_service/controller/OrderController.java
+++ b/src/main/java/shop/wannab/order_payment_service/controller/OrderController.java
@@ -2,10 +2,8 @@ package shop.wannab.order_payment_service.controller;
 
 import feign.FeignException;
 import jakarta.validation.Valid;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import shop.wannab.order_payment_service.client.BookClient;
@@ -24,8 +22,25 @@ public class OrderController {
     private final BookClient bookClient;
     private final OrderService orderService;
 
+    @PostMapping("/orders/items")
+    void produceOrderPageDto(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestParam(required = false) Long guestId, @RequestBody OrderItemListDto orderItemListDto) {
+        if (Objects.nonNull(userId)) {
+            orderService.saveTemporaryOrderInfo(userId, orderItemListDto);
+        } else if (Objects.isNull(userId) && Objects.nonNull(guestId)) {
+            orderService.saveTemporaryOrderInfo(guestId, orderItemListDto);
+        }
+    }
+
     @PostMapping("/orders")
-    public OrderPageRequestDto getNecesaryOrderInfo(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestParam(required = false) Long guestId, @RequestBody OrderItemListDto orderItemListDto) {
+    public OrderPageRequestDto consumeOrderPageDto(@RequestHeader(value = "X-USER-ID", required = false) Long userId, @RequestParam(required = false) Long guestId) {
+        OrderItemListDto orderItemListDto = null;
+
+        if (Objects.nonNull(userId)) {
+            orderItemListDto = orderService.consumeTemporaryOrderInfo(userId);
+        } else if (Objects.isNull(userId) && Objects.nonNull(guestId)) {
+            orderItemListDto = orderService.consumeTemporaryOrderInfo(guestId);
+        }
+
         try {
             bookClient.validateOrderItems(orderItemListDto);
         } catch (FeignException.BadRequest e) {
@@ -131,6 +146,5 @@ public class OrderController {
         boolean result = orderService.isReviewable(userId, bookId);
         return ResponseEntity.ok(result);
     }
-
 
 }

--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderItemListDto.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderItemListDto.java
@@ -3,12 +3,14 @@ package shop.wannab.order_payment_service.entity.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 public class OrderItemListDto {
     private List<CartItem> orderItems;
 }

--- a/src/main/java/shop/wannab/order_payment_service/repository/OrderItemTempRedisRepository.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/OrderItemTempRedisRepository.java
@@ -1,0 +1,46 @@
+package shop.wannab.order_payment_service.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import shop.wannab.order_payment_service.entity.dto.CartItem;
+import shop.wannab.order_payment_service.entity.dto.OrderItemListDto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderItemTempRedisRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String PREFIX = "TMP: ";
+
+    public void saveTemporaryOrderInfo(long customerId, OrderItemListDto dto) {
+        String key = PREFIX + customerId;
+        List<CartItem> orderItems = dto.getOrderItems();
+        for (CartItem item : orderItems) {
+            redisTemplate.opsForHash().put(key, item.getBookId(), item.getQuantity());
+        }
+    }
+
+    public List<CartItem> consumeOrderItems(Long customerId) {
+        List<CartItem> cartItems = new ArrayList<>();
+        if (Objects.isNull(customerId)) {
+            return cartItems;
+        }
+        String key = PREFIX + customerId;
+        Map<Long, Integer> itemMap = redisTemplate.<Long, Integer>opsForHash().entries(key); //key: bookId, value: quantity
+
+        for (Map.Entry<Long, Integer> entry : itemMap.entrySet()) {
+            CartItem item = new CartItem(entry.getKey(), entry.getValue());
+            cartItems.add(item);
+            redisTemplate.opsForHash().delete(key, item.getBookId());
+        }
+
+        return cartItems;
+    }
+
+
+}

--- a/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
@@ -1,9 +1,6 @@
 package shop.wannab.order_payment_service.service;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -20,10 +17,7 @@ import shop.wannab.order_payment_service.client.UserClient;
 import shop.wannab.order_payment_service.entity.*;
 import shop.wannab.order_payment_service.entity.dto.*;
 
-import shop.wannab.order_payment_service.repository.GuestRepository;
-import shop.wannab.order_payment_service.repository.OrderBookRepository;
-import shop.wannab.order_payment_service.repository.OrderRepository;
-import shop.wannab.order_payment_service.repository.WrappingPaperRepository;
+import shop.wannab.order_payment_service.repository.*;
 import shop.wannab.order_payment_service.service.Impl.OrderEmailHelper;
 
 @Slf4j
@@ -41,6 +35,7 @@ public class OrderService {
     private final GuestRepository guestRepository;
     private final OrderBookRepository orderBookRepository;
     private final WrappingPaperRepository wrappingPaperRepository;
+    private final OrderItemTempRedisRepository orderItemTempRedisRepository;
     private final OrderEmailHelper orderEmailHelper;
 
     public OrderPageRequestDto createOrderPageRequestDto(Long userId, OrderItemListDto orderItemListDto) {
@@ -559,6 +554,13 @@ public class OrderService {
         );
     }
 
+    public void saveTemporaryOrderInfo(long customerId, OrderItemListDto dto) {
+        orderItemTempRedisRepository.saveTemporaryOrderInfo(customerId, dto);
+    }
 
+    public OrderItemListDto consumeTemporaryOrderInfo(long customerId) {
+        List<CartItem> orderItems = orderItemTempRedisRepository.consumeOrderItems(customerId);
+        return new OrderItemListDto(orderItems);
+    }
 
 }


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

프론트의 주문 페이지 입장로직 변경에 따른 주문api 수정

## 🔎 작업 상세 내용

- [x] 레디스 이용하여 주문페이지 생성에 일시적으로 필요한 정보 저장
- [x] 레디스에 저장된 정보 처리후 삭제
      
## ⏰ Pull Request 마감시간
> 

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #112 
