### PR TITLE
118:도서재고차감 비동기요청 구현

### DIFF
--- a/src/main/java/shop/wannab/order_payment_service/config/RabbitConfig.java
+++ b/src/main/java/shop/wannab/order_payment_service/config/RabbitConfig.java
@@ -1,0 +1,37 @@
+package shop.wannab.order_payment_service.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitConfig {
+    public static final String EXCHANGE = "wannab.order.exchange";
+    public static final String ORDER_CREATED_QUEUE = "wannab.order.created.queue";
+    public static final String ROUTING_KEY = "order.created";
+
+    @Bean
+    public TopicExchange exchange() {
+        return new TopicExchange(EXCHANGE);
+    }
+
+    @Bean
+    public Queue orderCreatedQueue() {
+        return new Queue(ORDER_CREATED_QUEUE);
+    }
+
+    @Bean
+    public Binding bindingProduct() {
+        return BindingBuilder.bind(orderCreatedQueue()).to(exchange()).with(ROUTING_KEY);
+    }
+
+    @Bean
+    public MessageConverter messageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/event/OrderCreatedEvent.java
+++ b/src/main/java/shop/wannab/order_payment_service/event/OrderCreatedEvent.java
@@ -1,0 +1,16 @@
+package shop.wannab.order_payment_service.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import shop.wannab.order_payment_service.entity.dto.OrderItemListDto;
+
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+@Setter
+public class OrderCreatedEvent {
+    private Long orderId;
+    private OrderItemListDto itemListDto;
+}

--- a/src/main/java/shop/wannab/order_payment_service/event/OrderEventHandler.java
+++ b/src/main/java/shop/wannab/order_payment_service/event/OrderEventHandler.java
@@ -1,0 +1,27 @@
+package shop.wannab.order_payment_service.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static shop.wannab.order_payment_service.config.RabbitConfig.EXCHANGE;
+import static shop.wannab.order_payment_service.config.RabbitConfig.ROUTING_KEY;
+
+@Component
+@RequiredArgsConstructor
+public class OrderEventHandler {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final ObjectMapper objectMapper;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCreated(OrderCreatedEvent event) throws JsonProcessingException {
+        String json = objectMapper.writeValueAsString(event);
+        rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, json);
+
+    }
+}

--- a/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
@@ -5,6 +5,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -17,6 +18,7 @@ import shop.wannab.order_payment_service.client.UserClient;
 import shop.wannab.order_payment_service.entity.*;
 import shop.wannab.order_payment_service.entity.dto.*;
 
+import shop.wannab.order_payment_service.event.OrderCreatedEvent;
 import shop.wannab.order_payment_service.repository.*;
 import shop.wannab.order_payment_service.service.Impl.OrderEmailHelper;
 
@@ -36,6 +38,8 @@ public class OrderService {
     private final OrderBookRepository orderBookRepository;
     private final WrappingPaperRepository wrappingPaperRepository;
     private final OrderItemTempRedisRepository orderItemTempRedisRepository;
+
+    private final ApplicationEventPublisher eventPublisher;
     private final OrderEmailHelper orderEmailHelper;
 
     public OrderPageRequestDto createOrderPageRequestDto(Long userId, OrderItemListDto orderItemListDto) {
@@ -79,9 +83,6 @@ public class OrderService {
 
         OrderItemListDto itemListDto = new OrderItemListDto(itemList);
         bookClient.validateOrderItems(itemListDto);
-
-        //------- 검증 끝-------//
-        bookClient.decreaseStock(itemListDto);
 
         List<Long> bookIds = orderSubmitDto.getBookOrderSubmitDtos().stream().map(BookOrderSubmitDto::getBookId).toList();
         BookIdTitlePriceListDto bookSimpleInfos = bookClient.getBookSimpleInfos(new BookIdListDto(bookIds));
@@ -147,6 +148,7 @@ public class OrderService {
         }
         int payAmount = order.getTotalPrice();
 
+        eventPublisher.publishEvent(new OrderCreatedEvent(order.getId(), itemListDto));
         OrderInfoForPayment orderInfoForPayment = new OrderInfoForPayment(order.getId(), orderName, payAmount);
         return orderInfoForPayment;
     }


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?
기존에 주문생성 메서드에서, 재고차감후 주문생성 실패시 문제가 생기는 경우가 있어, 주문생성 성공시(커밋완료시) 도서api에 도서재고차감 비동기 요청을 합니다.

## 🔎 작업 상세 내용

- [x] RabbitMq설정
- [x] createOrder메서드내 도서api에 재고차감요청 코드 삭제
- [x] createOrder메서드 트랜잭션 완료후 재고차감 비동기요청 구현
      
## ⏰ Pull Request 마감시간
> 7.11.20h

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #118 
