### PR TITLE
issue-126/fix : 회원주문목록에 도서 썸네일추가

### DIFF
--- a/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderLookupResponse.java
+++ b/src/main/java/shop/wannab/order_payment_service/entity/dto/OrderLookupResponse.java
@@ -2,17 +2,37 @@ package shop.wannab.order_payment_service.entity.dto;
 
 import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import shop.wannab.order_payment_service.entity.OrderStatus;
 
 
 //주문목록조회시 클라이언트에게 보여줄 정보 (현재페이지에선 도서정보도 포함하는데 지워도될듯)
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class OrderLookupResponse {
-    private final Long orderId;
-    private final String orderName;
-    private final LocalDateTime orderAt;    //주문일시
-    private final OrderStatus orderStatus;  //배송상태
-    private final LocalDateTime shippedAt; //출고일
-    private final int totalPrice;
+    private Long orderId;
+    private String orderName;
+    private LocalDateTime orderAt;    //주문일시
+    private OrderStatus orderStatus;  //배송상태
+    private LocalDateTime shippedAt; //출고일
+    private int totalPrice;
+    private String thumbnailUrl;
+
+    public OrderLookupResponse(Long orderId, String orderName, LocalDateTime orderAt,
+                               OrderStatus orderStatus, LocalDateTime shippedAt, int totalPrice) {
+        this.orderId = orderId;
+        this.orderName = orderName;
+        this.orderAt = orderAt;
+        this.orderStatus = orderStatus;
+        this.shippedAt = shippedAt;
+        this.totalPrice = totalPrice;
+    }
+
 }
+
+
+
+

--- a/src/main/java/shop/wannab/order_payment_service/repository/OrderBookRepository.java
+++ b/src/main/java/shop/wannab/order_payment_service/repository/OrderBookRepository.java
@@ -14,4 +14,7 @@ public interface OrderBookRepository extends JpaRepository<OrderBook, Long> {
 
     //배송완료체크
     boolean existsByOrder_UserIdAndBookIdAndOrder_OrderStatus(Long userId, Long bookId, OrderStatus orderStatus);
+
+    //회원주문목록 썸네일 가져오기위해
+    OrderBook findTop1ByOrder_IdOrderByObIdAsc(Long orderId);
 }

--- a/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
@@ -280,14 +280,32 @@ public class OrderService {
         Pageable pageable = PageRequest.of(page, size, Sort.by("orderAt").descending());
 
         return orderRepository.findAllByUserIdAndOrderStatusNot(userId, OrderStatus.FAILED, pageable)
-                .map(order -> new OrderLookupResponse(
-                        order.getId(),
-                        order.getOrderName(),
-                        order.getOrderAt(),
-                        order.getOrderStatus(),
-                        order.getShippedAt(),
-                        order.getTotalPrice()
-                ));
+                .map(order -> {
+                    OrderBook orderBook = orderBookRepository.findTop1ByOrder_IdOrderByObIdAsc(order.getId());
+                    String thumbnailUrl = null;
+
+                    if (orderBook != null) {
+                        // 도서 썸네일 외부에서 받아오기
+                        OrderItemListDto oneBook = new OrderItemListDto(
+                                List.of(new CartItem(orderBook.getBookId(), orderBook.getQuantity()))
+                        );
+                        OrderBookInfoListDto bookInfo = bookClient.getOrderBookInfos(oneBook);
+
+                        if (!bookInfo.getOrderBookInfos().isEmpty()) {
+                            thumbnailUrl = bookInfo.getOrderBookInfos().get(0).getThumbnailUrl();
+                        }
+                    }
+
+                    return new OrderLookupResponse(
+                            order.getId(),
+                            order.getOrderName(),
+                            order.getOrderAt(),
+                            order.getOrderStatus(),
+                            order.getShippedAt(),
+                            order.getTotalPrice(),
+                            thumbnailUrl // 썸네일 포함해서 DTO 리턴
+                    );
+                });
     }
 
     // 쇼핑몰 주문 전체 조회 (관리자용)


### PR DESCRIPTION

## 🥳 어떤 기능을 구현했나요?

> 회원주문목록에 도서썸네일을 추가

## 🔎 작업 상세 내용

- [x] DTO 수정 및 그에따른 service로직 변경
- [x] 주문관리와 회원주문목록 DTO를 같이쓰기때문에 주문관리에는 썸네일이 필요없어서 썸네일없는 생성자 추가

      
## ⏰ Pull Request 마감시간
> 7/15 10:00

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #126 
