### PR TITLE
fix: 비회원일시 결제성공후 비동기 요청 시도하지 않도록 수정

### DIFF
--- a/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/OrderService.java
@@ -133,13 +133,13 @@ public class OrderService {
             guestRepository.save(guest);
         }
 
-
-
-        PointHistoryCreateDTO pointHistoryCreateDTO = new PointHistoryCreateDTO(userId,
+        if (userId > 0) {
+            PointHistoryCreateDTO pointHistoryCreateDTO = new PointHistoryCreateDTO(userId,
                                                                                 orderSubmitDto.getUsedPoints() == null ? 0 : orderSubmitDto.getUsedPoints(),
                                                                                 order.getTotalPrice(),
                                                                                 order.getId());
-        pointHistoryCreateDtoRepository.save(pointHistoryCreateDTO);
+            pointHistoryCreateDtoRepository.save(pointHistoryCreateDTO);
+        }
 
         int payAmount = order.getTotalPrice();
 

--- a/src/main/java/shop/wannab/order_payment_service/service/PaymentService.java
+++ b/src/main/java/shop/wannab/order_payment_service/service/PaymentService.java
@@ -93,11 +93,13 @@ public class PaymentService {
             List<CartItem> orderItems = itemTempRedisRepository.getOrderItems(order.getUserId());
             OrderItemListDto itemListDto = new OrderItemListDto(orderItems);
 
-            PointHistoryCreateDTO pointHistoryCreateDTO = pointHistoryCreateDtoRepository.consumeByOrderId(orderId);
+            PointHistoryCreateDTO pointHistoryCreateDTO = null;
 
             List<CouponUsageRequestDto.UsedCouponInfo> usedCouponInfos = null;
             if (Objects.nonNull(order.getUserId())) {
                 usedCouponInfos = couponUsageTempRedisRepository.consumeUsedCouponInfos(order.getUserId());
+                pointHistoryCreateDTO = pointHistoryCreateDtoRepository.consumeByOrderId(orderId);
+
             }
 
             CouponUsageRequestDto couponUsageRequestDto = new CouponUsageRequestDto();


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

비회원이 결제성공후, 포인트처리하는것을 막음

## 🔎 작업 상세 내용

- [x] 유저의 경우에만 포인트 처리 가능토록 구현
      
## ⏰ Pull Request 마감시간
> 7.15.20h

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #이슈번호
